### PR TITLE
Snackbar 更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules
 dist
+package-lock.json
+yarn.lock
 pnpm-lock.yaml
+.vscode/*
+!.vscode/extensions.json

--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,8 @@
 src/
 node_modules/
 .gitattributes
+package-lock.json
+yarn.lock
 pnpm-lock.yaml
 tsconfig.json
 dev/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "tabWidth": 2,
+    "singleQuote": true,
+    "semi": false
+}

--- a/src/snackbar.ts
+++ b/src/snackbar.ts
@@ -5,6 +5,7 @@ import { Theme } from './page.js'
 const name = 's-snackbar'
 const props = {
   type: 'basic' as 'basic' | 'error',
+  position: 'auto' as 'auto' | 'top-center' | 'bottom-center',
   duration: 4000
 }
 
@@ -50,10 +51,6 @@ const style = /*css*/ `
   filter: opacity(0);
   transition: transform .2s, filter .2s;
   transition-timing-function: ease-out;
-}
-.wrapper.show .container{
-  transform: translateY(0%);
-  filter: opacity(1);
 }
 :host([type=error]) .container{
   background: var(--s-color-error, ${Theme.colorError});
@@ -118,6 +115,25 @@ const style = /*css*/ `
     min-width: 240px;
   }
 }
+:host([position=bottom-center]) .wrapper {
+  --offset-direction: -1;
+}
+:host([position=bottom-center]) .container{
+  transform: translateY(calc(100% - 16px));
+  min-width: 320px;
+}
+:host([position=top-center]) .wrapper{
+  align-items: flex-start;
+  --offset-direction: 1;
+}
+:host([position=top-center]) .container{
+  transform: translateY(calc(-100% - 16px));
+  min-width: 240px;
+}
+.wrapper.show .container{
+  transform: translateY(0%);
+  filter: opacity(1);
+}
 `
 
 const template = /*html*/`
@@ -144,6 +160,7 @@ const show = (options: string | {
   root?: Element
   text: string
   type?: typeof props['type']
+  position?: typeof props['position']
   duration?: number
   icon?: string | Element
   action?: string | {
@@ -164,6 +181,7 @@ const show = (options: string | {
     if (options.root) root = options.root
     snackbar.textContent = options.text
     snackbar.type = options.type ?? 'basic'
+    snackbar.position = options.position ?? 'auto'
     if (options.icon) {
       const icon = document.createElement('s-icon')
       icon.slot = 'icon'
@@ -195,10 +213,35 @@ const show = (options: string | {
   return snackbar
 }
 
-const task: { height: number, wrapper: HTMLElement }[] = []
+const task: { height: number, wrapper: HTMLElement, position: 'top-center' | 'bottom-center', propPosition: typeof props['position'] }[] = []
+const isMobileQuery: MediaQueryList = window.matchMedia('(pointer: coarse)')
+let isMobile: boolean = isMobileQuery.matches
+isMobileQuery.addEventListener('change', (query) => {
+  isMobile = query.matches
+  // debugger
+  if (task.length > 0) {
+    for (const item of task) {
+      if (item.propPosition === 'auto') {
+        item.position = isMobile ? 'top-center' : 'bottom-center'
+        // item.wrapper.style.setProperty('--offset', '0px')
+      }
+    }
+    let offsetTop = 0, offsetBottom = 0;
+    for (const item of task) {
+      if (item.position === 'top-center') {
+        item.wrapper.style.setProperty('--offset', `${offsetTop}px`)
+        offsetTop += item.height + 8
+      }
+      if (item.position === 'bottom-center') {
+        item.wrapper.style.setProperty('--offset', `${offsetBottom}px`)
+        offsetBottom += item.height + 8
+      }
+    }
+  }
+})
 
 class Snackbar extends useElement({
-  style, template, props, syncProps: ['type'],
+  style, template, props, syncProps: ['type', 'position'],
   setup(shadowRoot) {
     const trigger = shadowRoot.querySelector('slot[name=trigger]') as HTMLSlotElement
     const wrapper = shadowRoot.querySelector('.wrapper') as HTMLDivElement
@@ -206,6 +249,7 @@ class Snackbar extends useElement({
     const action = shadowRoot.querySelector('slot[name=action]') as HTMLElement
     const state = { timer: 0, task: null as null | typeof task[number] }
     const show = () => {
+      // debugger
       if (wrapper.classList.contains('show')) return
       const stackingContext = getStackingContext(shadowRoot)
       if (stackingContext.top !== 0 || stackingContext.left !== 0) {
@@ -214,14 +258,17 @@ class Snackbar extends useElement({
         wrapper.style.top = `${0 - stackingContext.top}px`
         wrapper.style.left = `${0 - stackingContext.left}px`
       }
+      const position = this.position === 'auto' ? (isMobile ? 'top-center' : 'bottom-center') : this.position
       let offset = container.offsetHeight + 8
       if (task.length > 0) {
         for (const item of task) {
-          item.wrapper.style.setProperty('--offset', `${offset}px`)
-          offset += item.height + 8
+          if (item.position === position) {
+            item.wrapper.style.setProperty('--offset', `${offset}px`)
+            offset += item.height + 8
+          }
         }
       }
-      task.unshift(state.task = { height: container.offsetHeight, wrapper })
+      task.unshift(state.task = { height: container.offsetHeight, wrapper, position: position, propPosition: this.position })
       wrapper.classList.add('show')
       this.dispatchEvent(new Event('show'))
       if (this.duration > 0) state.timer = setTimeout(dismiss, this.duration)
@@ -232,10 +279,13 @@ class Snackbar extends useElement({
       wrapper.classList.remove('show')
       this.dispatchEvent(new Event('dismiss'))
       const indexOf = task.indexOf(state.task!)
+      const position = this.position === 'auto' ? (isMobile ? 'top-center' : 'bottom-center') : this.position
       for (let i = indexOf + 1; i < task.length; i++) {
         const item = task[i]
-        const offset = Number(item.wrapper.style.getPropertyValue('--offset').slice(0, -2))
-        item.wrapper.style.setProperty('--offset', `${offset - 8 - container.offsetHeight}px`)
+        if (item.position === position) {
+          const offset = Number(item.wrapper.style.getPropertyValue('--offset').slice(0, -2))
+          item.wrapper.style.setProperty('--offset', `${offset - 8 - container.offsetHeight}px`)
+        }
       }
       task.splice(indexOf, 1)
     }

--- a/src/snackbar.ts
+++ b/src/snackbar.ts
@@ -8,7 +8,7 @@ const props = {
   duration: 4000
 }
 
-const style = /*css*/`
+const style = /*css*/ `
 :host{
   display: inline-block;
   vertical-align: middle;
@@ -66,11 +66,14 @@ const style = /*css*/`
 :host([type=error]) .error{
   display: block;
 }
-.icon{
+.icon,
+::slotted(svg[slot=icon]),
+::slotted(s-icon[slot=icon]){
   width: 24px;
   height: 24px;
   flex-shrink: 0;
   fill: currentColor;
+  color: currentColor;
   margin-left: 16px;
   margin-right: -4px;
 }
@@ -121,12 +124,14 @@ const template = /*html*/`
 <slot name="trigger"></slot>
 <div class="wrapper" part="wrapper">
   <div class="container" part="container">
-    <svg class="icon hint" viewBox="0 -960 960 960">
-      <path d="M480-280q17 0 28.5-11.5T520-320q0-17-11.5-28.5T480-360q-17 0-28.5 11.5T440-320q0 17 11.5 28.5T480-280Zm-40-160h80v-240h-80v240Zm40 360q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"></path>
-    </svg>
-    <svg class="icon error" viewBox="0 -960 960 960">
-      <path d="m336-280 144-144 144 144 56-56-144-144 144-144-56-56-144 144-144-144-56 56 144 144-144 144 56 56ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"></path>
-    </svg>
+    <slot name="icon" part="icon">
+      <svg class="icon hint" viewBox="0 -960 960 960">
+        <path d="M480-280q17 0 28.5-11.5T520-320q0-17-11.5-28.5T480-360q-17 0-28.5 11.5T440-320q0 17 11.5 28.5T480-280Zm-40-160h80v-240h-80v240Zm40 360q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"></path>
+      </svg>
+      <svg class="icon error" viewBox="0 -960 960 960">
+        <path d="m336-280 144-144 144 144 56-56-144-144 144-144-56-56-144 144-144-144-56 56 144 144-144 144 56 56ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"></path>
+      </svg>
+    </slot>
     <div class="text" part="text">
       <slot></slot>
     </div>
@@ -140,6 +145,7 @@ const show = (options: string | {
   text: string
   type?: typeof props['type']
   duration?: number
+  icon?: string | Element
   action?: string | {
     text: string
     click: (event: MouseEvent) => unknown
@@ -158,6 +164,17 @@ const show = (options: string | {
     if (options.root) root = options.root
     snackbar.textContent = options.text
     snackbar.type = options.type ?? 'basic'
+    if (options.icon) {
+      const icon = document.createElement('s-icon')
+      icon.slot = 'icon'
+      if (typeof options.icon === 'string') {
+        icon.innerHTML = options.icon
+      }
+      else {
+        icon.appendChild(options.icon)
+      }
+      snackbar.appendChild(icon)
+    }
     if (options.action) {
       const action = document.createElement('s-button')
       action.type = 'text'

--- a/test/index.html
+++ b/test/index.html
@@ -985,8 +985,29 @@
       <s-button type="text" slot="action"> 关闭 </s-button>
     </s-snackbar>
 
+    <s-snackbar duration="0">
+      <s-button slot="trigger"> Snackbar 4 </s-button>
+      <s-icon slot="icon" type="star"></s-icon>
+      Snackbar Message 4
+      <s-button type="text" slot="action"> 关闭 </s-button>
+    </s-snackbar>
+
+     <s-snackbar duration="0">
+      <s-button slot="trigger"> Snackbar 5 </s-button>
+      <div slot="icon"></div>
+      Snackbar Message 5
+    </s-snackbar>
+
     <s-button
-      onclick="window.customElements.get('s-snackbar').show({text: `提示：${new Date}`, duration:Math.max( Math.random()*10000, 4000)})">Snackbar2</s-button>
+      onclick="window.customElements.get('s-snackbar').show({text: `提示：${new Date}`, duration:Math.max( Math.random()*10000, 4000)})">Snackbar 6</s-button>
+    <s-button
+      onclick="window.customElements.get('s-snackbar').show({text: `提示：${new Date}`, icon: 
+        '<svg viewBox=\&quot;0 -960 960 960\&quot;><path d=\&quot;\M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Z&quot;></path></svg>',
+        duration:0})">Snackbar 7</s-button>
+    <s-button
+      onclick="let svg = document.createElement('svg');
+      svg.innerHTML='<svg viewBox=\&quot;0 -960 960 960\&quot;><path d=\&quot;\M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Z&quot;></path></svg>';
+      window.customElements.get('s-snackbar').show({text: `提示：${new Date}`, icon: svg, duration:0})">Snackbar 8</s-button>
     <hr>
     <s-tooltip>
       <s-button slot="trigger">Tooltip</s-button>

--- a/test/index.html
+++ b/test/index.html
@@ -968,46 +968,46 @@
     </s-popup-menu>
     <hr>
     <s-snackbar duration="0">
-      <s-button slot="trigger"> Snackbar 1 </s-button>
+      <s-button slot="trigger"> Snackbar 1 (No Duration) </s-button>
       Snackbar Message 1
       <s-button type="text" slot="action"> 关闭 </s-button>
     </s-snackbar>
 
-    <s-snackbar duration="0" type="warning">
-      <s-button slot="trigger"> Snackbar 2 </s-button>
+    <s-snackbar duration="0" type="warning" position="top-center">
+      <s-button slot="trigger"> Snackbar 2 (Top Center) </s-button>
       Snackbar Message 2
       <s-button type="text" slot="action"> 关闭 </s-button>
     </s-snackbar>
 
-    <s-snackbar duration="0" type="error">
-      <s-button slot="trigger"> Snackbar 3 </s-button>
+    <s-snackbar duration="0" type="error" position="bottom-center">
+      <s-button slot="trigger"> Snackbar 3 (Bottom Center) </s-button>
       Snackbar Message 3
       <s-button type="text" slot="action"> 关闭 </s-button>
     </s-snackbar>
 
     <s-snackbar duration="0">
-      <s-button slot="trigger"> Snackbar 4 </s-button>
+      <s-button slot="trigger"> Snackbar 4 (Custom Icon) </s-button>
       <s-icon slot="icon" type="star"></s-icon>
       Snackbar Message 4
       <s-button type="text" slot="action"> 关闭 </s-button>
     </s-snackbar>
 
-     <s-snackbar duration="0">
-      <s-button slot="trigger"> Snackbar 5 </s-button>
+    <s-snackbar>
+      <s-button slot="trigger"> Snackbar 5 (No Icon) </s-button>
       <div slot="icon"></div>
       Snackbar Message 5
     </s-snackbar>
 
     <s-button
-      onclick="window.customElements.get('s-snackbar').show({text: `提示：${new Date}`, duration:Math.max( Math.random()*10000, 4000)})">Snackbar 6</s-button>
+      onclick="window.customElements.get('s-snackbar').show({text: `提示：${new Date}`, duration:Math.max( Math.random()*10000, 4000)})">Snackbar 6 (Dynamic) </s-button>
     <s-button
-      onclick="window.customElements.get('s-snackbar').show({text: `提示：${new Date}`, icon: 
+      onclick="window.customElements.get('s-snackbar').show({text: `提示：${new Date}`, position: 'top-center', icon: 
         '<svg viewBox=\&quot;0 -960 960 960\&quot;><path d=\&quot;\M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Z&quot;></path></svg>',
-        duration:0})">Snackbar 7</s-button>
+        duration:Math.max( Math.random()*10000, 4000)})">Snackbar 7 (Dynamic with SVG String) </s-button>
     <s-button
       onclick="let svg = document.createElement('svg');
       svg.innerHTML='<svg viewBox=\&quot;0 -960 960 960\&quot;><path d=\&quot;\M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Z&quot;></path></svg>';
-      window.customElements.get('s-snackbar').show({text: `提示：${new Date}`, icon: svg, duration:0})">Snackbar 8</s-button>
+      window.customElements.get('s-snackbar').show({text: `提示：${new Date}`, icon: svg, duration:Math.max( Math.random()*10000, 4000)})">Snackbar 8 (Dynamic with SVG Element) </s-button>
     <hr>
     <s-tooltip>
       <s-button slot="trigger">Tooltip</s-button>


### PR DESCRIPTION
根据 #22 对 Snackbar 进行一些更新

* [x]  允许用户自定义s-snackbar的弹出方向比如说自定义PC或触屏下弹出方向
  * [ ]  多弄点弹出方向，比如从左到右、从右到左之类
* [ ]  弄个静态的s-snackbar，可以理解为套着s-snackbar外观的容器
* [x]  添加图标插槽，可以控制是否有图标、图标内容，没有再使用默认图标
* [x]  允许设置超时时间，比如`0`为永不隐藏直到点击按钮
* [ ]  在snackbar下面增加一个可选的倒计时进度条来表明还有多久隐藏
* [x]  snackbar可以选择在哪个父控件内弹出而不是一直都在s-page或body下弹出