### PR TITLE
docs: correct "unckecked" typo to "unchecked"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - 新增：Alert、Avatar、Date、DatePicker，Pagination 组件。
 - 新增：Switch 新增 icon 插槽，默认图标被移除。
 - 新增：BottomSheet 组件新增手势滑动，新增属性 `disabledGesture` 属性。
-- 新增：Checkbox 新增 **unckecked**、**checked**、**indeterminate** 插槽，用于自定义切换图标。
+- 新增：Checkbox 新增 **unchecked**、**checked**、**indeterminate** 插槽，用于自定义切换图标。
 - 更新：Chip 外观更新，新增属性 `checked`，`disabled`，type 属性值 elevated, filled-tonal 已弃用。
 - 新增组件：DatePicier 日期选择器。
 - 新增组件：Date 日期选择面板。
@@ -31,7 +31,7 @@
 - 新增组件：Pagination 分页选择器。
 - 更新：Picker 组件弹出层宽度抖动问题，新增 `show()`、`close()`、`toggle()` 方法，参数同 Popup 组件。
 - 更新：PopupMenu 组件新增 `show()`、`close()`、`toggle()` 方法，参数同 Popup 组件。
-- 新增：RadioButton 新增 **unckecked**、**checked** 插槽，用于自定义切换图标。
+- 新增：RadioButton 新增 **unchecked**、**checked** 插槽，用于自定义切换图标。
 - 更新：Search 组件样式更新。
 - 更新：SegmentedButton 组件 UI 更新，新增属性 `mode`。
 - 修复：Slider 组件设置 `min` 属性时指示器错位问题。

--- a/docs/zh-cn/Checkbox.md
+++ b/docs/zh-cn/Checkbox.md
@@ -71,7 +71,7 @@ s-checkbox[checked=true] {
 
 | 名称          | 介绍     |
 | ------------- | ------- |
-| unckecked     | 未选中   |
+| unchecked     | 未选中   |
 | checked       | 已选中   |
 | indeterminate | 未知状态 |
 

--- a/docs/zh-cn/RadioButton.md
+++ b/docs/zh-cn/RadioButton.md
@@ -71,7 +71,7 @@ s-radio-button[checked=true] {
 
 | 名称      | 介绍    |
 | --------- | ------ |
-| unckecked | 未选中 |
+| unchecked | 未选中 |
 | checked   | 已选中 |
 
 ---


### PR DESCRIPTION
## Summary

Fix the typo `unckecked` → `unchecked` across docs and changelog.

- `CHANGELOG.md`: Checkbox / RadioButton slot entries
- `docs/zh-cn/Checkbox.md`: slot table
- `docs/zh-cn/RadioButton.md`: slot table

The actual slot names in `src/checkbox.ts` and `src/radio-button.ts` are already `unchecked` — only the documentation had the misspelling.

Closes #59