### PR TITLE
fix(docs): correct "multiLine" type to "multiline" in text-field example

### DIFF
--- a/docs/zh-cn/TextField.md
+++ b/docs/zh-cn/TextField.md
@@ -6,7 +6,7 @@
 <s-text-field label="请输入文本"></s-text-field>
 <s-text-field label="请输入数字" type="number"></s-text-field>
 <s-text-field label="请输入密码" type="password"></s-text-field>
-<s-text-field label="请输入多行文本" type="multiLine" style="min-height: 96px"></s-text-field>
+<s-text-field label="请输入多行文本" type="multiline" style="min-height: 96px"></s-text-field>
 ```
 
 使用 `start` 和 `end` 插槽来添加图标或者图标按钮。


### PR DESCRIPTION
Fixes #61

在 text-field 文档的多行文本示例中，`type` 属性使用了 `type="multiLine"`，但组件的有效类型是 `multiline`（见 `src/text-field.ts`）。这会导致多行文本设置失败。将示例中的 `type="multiLine"` 修正为 `type="multiline"`。